### PR TITLE
Fixing typo in the readme project path

### DIFF
--- a/localnet/README.md
+++ b/localnet/README.md
@@ -9,7 +9,7 @@ $(go env GOPATH)/src/github.com/harmony-one/harmony
 ```
 * This repo follows the GO-PATH convention. So the path to said repo must be:
 ```bash
-$(go env GOPATH)/src/github.com/harmony-one/harmony-tests
+$(go env GOPATH)/src/github.com/harmony-one/harmony-test
 ```
 * No extra transactions on the localnet are done prior to running the pytest in `./tests` or execution of the rosetta integration test.
 * The localnet faucet address is `one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur` 


### PR DESCRIPTION
Github project name and README.md path are different and, when testing, location does not exist. 