### PR TITLE
fixing the broken test after the rpc reponse structure was updated in…

### DIFF
--- a/localnet/rpc_tests/test_blockchain.py
+++ b/localnet/rpc_tests/test_blockchain.py
@@ -196,24 +196,51 @@ def test_get_latest_chain_headers():
     Note that v1 & v2 have the same responses.
     """
     reference_response = {
-        "beacon-chain-header": {
-            "shard-id": 0,
-            "block-header-hash": "0x127437058641851cdfe10e9509aa060b169acbce79eb63d04e3be2cfbe596695",
-            "block-number": 171,
-            "view-id": 171,
-            "epoch": 33
-        },
-        "shard-chain-header": {
-            "shard-id": 1,
-            "block-header-hash": "0x0ca6c681e128f47e35e4c578b6381f3f8dda8ec9fcb0a8935a0bf12a2e7a19a3",
-            "block-number": 171,
-            "view-id": 171,
-            "epoch": 33
+        "id": "0",
+        "jsonrpc": "2.0",
+        "result": {
+            "beacon-chain-header": {
+                "epoch": 18,
+                "extraData": "0x",
+                "gasLimit": "0x4c4b400",
+                "gasUsed": "0x0",
+                "hash": "0xdb6099006bb637578a94fa3003b2b68947ae8fcdc7e9f89ea0f83edd5ad65c9e",
+                "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "miner": "0x6911b75b2560be9a8f71164a33086be4511fc99a",
+                "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "number": "0xab",
+                "parentHash": "0x9afbaa3db3c2f5393b7b765aa48091c7a6cc3c3fdf19fb88f8ee2c88e257988d",
+                "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                "shardID": 0,
+                "stateRoot": "0x4d0b5b168bd3214e32f95718ef591e04c54f060f89e4304c8d4ff2745ebad3a9",
+                "timestamp": "0x60751990",
+                "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                "viewID": 171
+            },
+            "shard-chain-header": {
+                "epoch": 17,
+                "extraData": "0x",
+                "gasLimit": "0x4c4b400",
+                "gasUsed": "0x0",
+                "hash": "0xdf4c2be8e676f728a419415bdd393a5c174e0b1431e016f870d0777d86668708",
+                "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "miner": "0xd06193871db8d5bc92dead4780e3624038174e88",
+                "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "number": "0xa7",
+                "parentHash": "0x336990a12d8697c5f9247790261aa1bdea33aed37031d09664680b86779f08a6",
+                "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                "shardID": 1,
+                "stateRoot": "0xddd8a842df3ffd77555d64ab782abf6effe95bc2eab48610ac05a5445b55df92",
+                "timestamp": "0x60751991",
+                "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                "viewID": 167
+            }
         }
     }
 
     # Check v1
-    raw_response = base_request("hmy_getLatestChainHeaders", endpoint=endpoints[1])
+    raw_response = base_request(
+        "hmy_getLatestChainHeaders", endpoint=endpoints[1])
     response = check_and_unpack_rpc_response(raw_response, expect_error=False)
     assert_valid_json_structure(reference_response, response)
     assert response["beacon-chain-header"]["shard-id"] == 0


### PR DESCRIPTION
fixing the broken test after the rpc reponse structure was updated in the main repo. the response structure of latest-headers is changed in https://github.com/harmony-one/harmony/pull/3655 