### PR TITLE
fix docker build failed for golang 1.16

### DIFF
--- a/localnet/Dockerfile
+++ b/localnet/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR $GOPATH/src/github.com/harmony-one
 
 SHELL ["/bin/bash", "-c"]
 
+RUN go mod download
+
 RUN apt update && apt upgrade -y && apt update -y && apt install unzip \
 libgmp-dev libssl-dev curl git jq make gcc g++ bash sudo python3 python3-pip -y
 


### PR DESCRIPTION
# PR

Related to this PR: https://github.com/harmony-one/harmony/pull/3720

#  Issue

- https://blog.golang.org/go116-module-changes    

`Build commands like go build and go test no longer modify go.mod and go.sum by default. Instead, they report an error if a module requirement or checksum needs to be added or updated (as if the -mod=readonly flag were used). Module requirements and sums may be adjusted with go mod tidy or go get.` 
