### PR TITLE
Fix travis script name

### DIFF
--- a/localnet/scripts/run.sh
+++ b/localnet/scripts/run.sh
@@ -57,7 +57,7 @@ function go_tests() {
     bash ./scripts/go_executable_build.sh -S
     BUILD=False
   fi
-  bash ./scripts/travis_checker.sh || error=1
+  bash ./scripts/travis_go_checker.sh || error=1
   echo -e "\n=== \e[38;5;0;48;5;255mFINISHED GO TESTS\e[0m ===\n"
   if ((error == 1)); then
     echo "FAILED GO TESTS"


### PR DESCRIPTION
Go tests fail because `./scripts/travis_checker.sh` does not exist.

---
Harmony (C) 2020. harmony, version v7066-v4.0.1-67-g73ab26cf (@ 2021-06-04T10:09:23+0000)
/go/src/github.com/harmony-one/harmony/bin /go/src/github.com/harmony-one/harmony
/go/src/github.com/harmony-one/harmony
**bash: ./scripts/travis_checker.sh: No such file or directory**

=== FINISHED GO TESTS ===

FAILED GO TESTS
/go/src/github.com/harmony-one/harmony
/go/src/github.com/harmony-one/harmony /go/src/github.com/harmony-one/harmony
/go/src/github.com/harmony-one/harmony
make: *** [Makefile:84: test-go] Error 1
