### PR TITLE
modify the go tests script path

### DIFF
--- a/localnet/scripts/run.sh
+++ b/localnet/scripts/run.sh
@@ -57,7 +57,7 @@ function go_tests() {
     bash ./scripts/go_executable_build.sh -S
     BUILD=False
   fi
-  bash ./scripts/travis_checker.sh || error=1
+  bash ./scripts/travis_go_checker.sh || error=1
   echo -e "\n=== \e[38;5;0;48;5;255mFINISHED GO TESTS\e[0m ===\n"
   if ((error == 1)); then
     echo "FAILED GO TESTS"


### PR DESCRIPTION
This PR fixes the problem that running `make test-go` in harmony-one/harmony fails with the following error message.
> bash: . /scripts/travis_checker.sh: No such file or directory

I don't know the details, but it seems that the script name change that caused the problem was made a long time ago, so the above test itself may not be important now.
Personally, I think it would be useful if this fix is incorporated and the image on the docker hub is updated.