### PR TITLE
improve rpc tests

### DIFF
--- a/localnet/scripts/run.sh
+++ b/localnet/scripts/run.sh
@@ -137,7 +137,7 @@ function wait_for_localnet_boot() {
     result=$(curl --silent --location --request POST "localhost:9500" \
       --header "Content-Type: application/json" \
       --data '{"jsonrpc":"2.0","method":"hmy_blockNumber","params":[],"id":1}' | jq '.result')
-    if [ $((result>0)) -eq 1 ]; then
+    if ((result>0)); then
       valid=true
     else 
       echo "Waiting for localnet to boot..."

--- a/localnet/scripts/run.sh
+++ b/localnet/scripts/run.sh
@@ -70,8 +70,9 @@ function go_tests() {
 function rpc_tests() {
   echo -e "\n=== \e[38;5;0;48;5;255mSTARTING RPC TESTS\e[0m ===\n"
   build_and_start_localnet || exit 1 &
-  sleep 20
-  wait_for_localnet_boot 100 # Timeout at ~300 seconds
+  sleep 30
+  # WARNING: Assumtion is that EPOCH 2 can process ALL test transaction types...
+  wait_for_epoch 2 300 # Timeout at ~900 seconds
 
   echo "Starting test suite..."
   sleep 3
@@ -136,7 +137,9 @@ function wait_for_localnet_boot() {
     result=$(curl --silent --location --request POST "localhost:9500" \
       --header "Content-Type: application/json" \
       --data '{"jsonrpc":"2.0","method":"hmy_blockNumber","params":[],"id":1}' | jq '.result')
-    if [ "$result" = "\"0x0\"" ]; then
+    if [ $((result>0)) -eq 1 ]; then
+      valid=true
+    else 
       echo "Waiting for localnet to boot..."
       if ((i > timeout)); then
         echo "TIMEOUT REACHED"
@@ -144,12 +147,9 @@ function wait_for_localnet_boot() {
       fi
       sleep 3
       i=$((i + 1))
-    else
-      valid=true
     fi
   done
 
-  sleep 15  # Give some slack to ensure localnet is booted...
   echo "Localnet booted."
 }
 

--- a/localnet/scripts/run.sh
+++ b/localnet/scripts/run.sh
@@ -136,7 +136,7 @@ function wait_for_localnet_boot() {
   until $valid; do
     result=$(curl --silent --location --request POST "localhost:9500" \
       --header "Content-Type: application/json" \
-      --data '{"jsonrpc":"2.0","method":"hmy_blockNumber","params":[],"id":1}' | jq '.result')
+      --data '{"jsonrpc":"2.0","method":"hmy_blockNumber","params":[],"id":1}' | jq -r '.result')
     if ((result>0)); then
       valid=true
     else 

--- a/localnet/scripts/run.sh
+++ b/localnet/scripts/run.sh
@@ -150,6 +150,7 @@ function wait_for_localnet_boot() {
     fi
   done
 
+  sleep 15  # Give some slack to ensure localnet is booted...
   echo "Localnet booted."
 }
 


### PR DESCRIPTION
RPC tests currently wait for the local net to boot before starting test suits. However, this approach sometimes fails, as the local net boot can timeout, and the test suits start regardless of the local net's readiness. This PR aims to enhance the process by introducing a wait for epoch 2 before initiating the RPC tests. This ensures that the local net is stable enough to run tests and reduces the occurrence of failures. This is same approach as we are already using for Rosetta tests.

Additionally, at line 139, the code checks the block number and assumes it is a valid block number if it's not equal to "0x0". This approach only works when the result contains a valid block number. In case the RPC call results in an error or fails for any reason or returns 0x0 but stuck at block 0, it will still be considered as valid because it is not equal to "0x0". This PR addresses this issue by ensuring that at least one block is produced before confirming the completeness of the boot process.