### PR TITLE
feat(Dockerfile) - add argument MAIN_REPO_BRANCH for Dockerfile to point to any branch in main harmony repo

### DIFF
--- a/localnet/Dockerfile
+++ b/localnet/Dockerfile
@@ -1,4 +1,10 @@
+ARG MAIN_REPO_BRANCH=dev
+
 FROM golang:1.19
+
+ARG MAIN_REPO_BRANCH
+
+ENV BRANCH=${MAIN_REPO_BRANCH}
 
 WORKDIR $GOPATH/src/github.com/harmony-one
 
@@ -12,7 +18,7 @@ RUN apt upgrade -y > /dev/null 2>1
 RUN apt update -y > /dev/null 2>1
 RUN apt install -y unzip libgmp-dev libssl-dev curl git jq make gcc g++ bash sudo python3 python3-pip > /dev/null 2>1
 
-RUN git clone https://github.com/harmony-one/harmony.git > /dev/null 2>1 \
+RUN git clone --branch ${BRANCH} https://github.com/harmony-one/harmony.git > /dev/null 2>1 \
     && git clone https://github.com/harmony-one/bls.git > /dev/null 2>1 \
     && git clone https://github.com/harmony-one/mcl.git > /dev/null 2>1
 


### PR DESCRIPTION
Note: this PR is a prerequisite for the RP in the main repo

What was done: 
* new variable MAIN_REPO_BRANCH is introduced to be able to point tests to any branch in the **main** `harmony` repo

It works together with `travis_rosetta_checker.sh` and `travis_rpc_checker.sh` in which we point to exact MAIN_REPO_BRANCH instead of main one.

You can check how it will work from main repo, yes, right now my fork, after this PR merge, I'll create a PR for the main repo  - https://github.com/mur-me/harmony/commit/ea75f8a13cad68a42f6d8c4522d4db14b2a06a50

Example of code with the new t[ravis RPC checker](https://github.com/mur-me/harmony/commit/ea75f8a13cad68a42f6d8c4522d4db14b2a06a50#diff-946302ec26b2fef1fc807e55571cd0bfef39ce4a1f75ae9eb761a982eac155ee): 
```
uladzislau@MURAVEIKANB:~/go/src/github.com/harmony-one/harmony$ TEST_REPO_BRANCH='feat_add_feature_to_point_dockerfile_against_non_main_branch' make travis_rpc_checker 
 => CACHED [ 8/23] RUN git clone --branch feat_add_feature_to_point_dockerfile_against_non_main_branch https://github.com/mur-me/harmony.git > /dev/null 2>1             
```
As you can see code now is using current local branch to as argument in the following line:
`docker build --build-arg MAIN_REPO_BRANCH="$(git rev-parse --abbrev-ref HEAD)" -t harmonyone/localnet-test .`