### PR TITLE
feat(RPC): cover effectiveGasPrice with tests in the hmy_getTransactionReceipt and hmyv2_getTransactionReceipt

### DIFF
--- a/localnet/rpc_tests/test_staking.py
+++ b/localnet/rpc_tests/test_staking.py
@@ -40,7 +40,8 @@ from utils import (
     assert_valid_json_structure,
     mutually_exclusive_test,
     rerun_delay_filter,
-    assert_no_null_in_list
+    assert_no_null_in_list,
+    is_valid_hex_string
 )
 
 _mutex_scope = "staking"
@@ -281,7 +282,7 @@ def test_get_transaction_receipt_v1(s0_validator):
         "transactionHash": "0xf80460f1ad041a0a0e841da717fc5b7959b1a7e9a0ce9a25cd70c0ce40d5ff26",
         "transactionIndex": "0x0",
         "type": "0x0",
-        "effectiveGasPrice": "0x5121c4",
+        "effectiveGasPrice": "0x6fc23ac00",
     }
 
     raw_response = base_request("hmy_getTransactionReceipt",
@@ -289,6 +290,8 @@ def test_get_transaction_receipt_v1(s0_validator):
                                 endpoint=endpoints[beacon_shard_id])
     response = check_and_unpack_rpc_response(raw_response, expect_error=False)
     assert_valid_json_structure(reference_response, response)
+    assert response["effectiveGasPrice"] == reference_response["effectiveGasPrice"]
+    assert is_valid_hex_string(response["effectiveGasPrice"])
     assert response["transactionHash"] == s0_validator["hash"], f"Expected transaction {s0_validator['hash']}, " \
                                                                 f"got {response['transactionHash']}"
 
@@ -301,6 +304,7 @@ def test_get_transaction_receipt_v2(s0_validator):
         "contractAddress": None,
         "cumulativeGasUsed": 5317060,
         "gasUsed": 5317060,
+        "effectiveGasPrice": 30000000000,
         "logs": [],
         "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         "sender": "one109r0tns7av5sjew7a7fkekg4fs3pw0h76pp45e",
@@ -308,7 +312,6 @@ def test_get_transaction_receipt_v2(s0_validator):
         "transactionHash": "0xf80460f1ad041a0a0e841da717fc5b7959b1a7e9a0ce9a25cd70c0ce40d5ff26",
         "transactionIndex": 0,
         "type": 0,
-        "effectiveGasPrice": 5317060,
     }
 
     raw_response = base_request("hmyv2_getTransactionReceipt",
@@ -316,6 +319,8 @@ def test_get_transaction_receipt_v2(s0_validator):
                                 endpoint=endpoints[beacon_shard_id])
     response = check_and_unpack_rpc_response(raw_response, expect_error=False)
     assert_valid_json_structure(reference_response, response)
+    assert response["effectiveGasPrice"] == reference_response["effectiveGasPrice"]
+    assert isinstance(response["effectiveGasPrice"], int), f"The value {response['effectiveGasPrice']} is not an integer."
     assert response["transactionHash"] == s0_validator["hash"], f"Expected transaction {s0_validator['hash']}, " \
                                                                 f"got {response['transactionHash']}"
 

--- a/localnet/rpc_tests/test_transaction.py
+++ b/localnet/rpc_tests/test_transaction.py
@@ -37,7 +37,8 @@ from utils import (
     check_and_unpack_rpc_response,
     assert_valid_json_structure,
     mutually_exclusive_test,
-    rerun_delay_filter
+    rerun_delay_filter,
+    is_valid_hex_string
 )
 
 
@@ -476,6 +477,7 @@ def test_get_transaction_receipt_v1():
         "blockNumber": "0x4",
         "contractAddress": None,
         "cumulativeGasUsed": "0x5208",
+        "effectiveGasPrice": "0x6fc23ac00",
         "from": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
         "gasUsed": "0x5208",
         "logs": [],
@@ -493,9 +495,12 @@ def test_get_transaction_receipt_v1():
                                 endpoint=endpoints[init_tx_record["from-shard"]])
     response = check_and_unpack_rpc_response(raw_response, expect_error=False)
     assert_valid_json_structure(reference_response, response)
+    assert response["effectiveGasPrice"] == reference_response["effectiveGasPrice"]
+    assert is_valid_hex_string(response["effectiveGasPrice"])
     assert response["transactionHash"] == init_tx_record["hash"], f"Expected transaction {init_tx_record['hash']}, " \
                                                                   f"got {response['transactionHash']}"
 
+# TODO: write test for eth_get_transaction_receipt
 
 @pytest.mark.run(order=0)
 def test_get_transaction_receipt_v2():
@@ -506,6 +511,7 @@ def test_get_transaction_receipt_v2():
         "cumulativeGasUsed": 21000,
         "from": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
         "gasUsed": 21000,
+        "effectiveGasPrice": 30000000000,
         "logs": [],
         "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         "shardID": 0,
@@ -521,6 +527,8 @@ def test_get_transaction_receipt_v2():
                                 endpoint=endpoints[init_tx_record["from-shard"]])
     response = check_and_unpack_rpc_response(raw_response, expect_error=False)
     assert_valid_json_structure(reference_response, response)
+    assert response["effectiveGasPrice"] == reference_response["effectiveGasPrice"]
+    assert isinstance(response["effectiveGasPrice"], int), f"The value {response['effectiveGasPrice']} is not an integer."
     assert response["transactionHash"] == init_tx_record["hash"], f"Expected transaction {init_tx_record['hash']}, " \
                                                                   f"got {response['transactionHash']}"
 

--- a/localnet/rpc_tests/txs.py
+++ b/localnet/rpc_tests/txs.py
@@ -363,7 +363,6 @@ def send_and_confirm_staking_transaction(tx_data, timeout=tx_timeout * 2):
         if tx_response is not None:
             if tx_response['blockNumber'] is not None:
                 return tx_response
-            assert tx_response['effectiveGasPrice'] is not None, "Could not find effectiveGasPrice fields in staking transaction."
         time.sleep(random.uniform(0.2, 0.5))  # Random to stop burst spam of RPC calls.
     raise AssertionError("Could not confirm staking transaction on-chain.")
 

--- a/localnet/rpc_tests/utils.py
+++ b/localnet/rpc_tests/utils.py
@@ -18,6 +18,36 @@ from pyhmy import (
 _mutually_exclusive_locks = {}
 
 
+def is_valid_hex_string(s: str) -> bool:
+    """
+    Check if the given string is a valid hexadecimal string.
+
+    A valid hexadecimal string is defined as a string that can be converted
+    to an integer using base 16. Strings with the "0x" prefix are also supported.
+
+    Args:
+        s (str): The string to validate.
+
+    Returns:
+        bool: True if the string is a valid hexadecimal string, False otherwise.
+
+    Examples:
+        >>> is_valid_hex_string("0x1A3F")
+        True
+        >>> is_valid_hex_string("123")
+        True
+        >>> is_valid_hex_string("0xXYZ")
+        False
+        >>> is_valid_hex_string("0x")
+        False
+    """
+    try:
+        int(s, 16)
+        return True
+    except ValueError:
+        return False
+
+
 def is_valid_json_rpc(response):
     """
     Checks if the given `response` is a valid JSON RPC 2.0 response.


### PR DESCRIPTION
What was done:
* fixed tests for both v1 and v2 hmy versions
* add one more check to utils for the hex string 