### PR TITLE
refactor(pyhmy): update to the latest pyhmy version, fix tests

### DIFF
--- a/localnet/requirements.txt
+++ b/localnet/requirements.txt
@@ -1,4 +1,4 @@
-pyhmy==20.5.16
+pyhmy==0.1.0
 pytest==6.2.5
 pytest-ordering==0.6
 pytest-xdist==1.33.0

--- a/localnet/rpc_tests/test_blockchain.py
+++ b/localnet/rpc_tests/test_blockchain.py
@@ -449,8 +449,8 @@ def test_get_block_transaction_count_by_number_v1():
 def test_get_block_transaction_count_by_number_v2():
     init_tx_record = initial_funding[0]
     init_tx = transaction.get_transaction_by_hash(init_tx_record["hash"], endpoints[init_tx_record["from-shard"]])
-
-    raw_response = base_request("hmyv2_getBlockTransactionCountByNumber", params=[int(init_tx["blockNumber"], 16)],
+    raw_response = base_request("hmyv2_getBlockTransactionCountByNumber",
+                                params=[int(init_tx["blockNumber"])],
                                 endpoint=endpoints[0])
     response = check_and_unpack_rpc_response(raw_response, expect_error=False)
     assert isinstance(response, int)
@@ -594,7 +594,7 @@ def test_get_blocks_v1():
 
     init_tx_record = initial_funding[0]
     init_tx = transaction.get_transaction_by_hash(init_tx_record["hash"], endpoints[init_tx_record["from-shard"]])
-    start_blk, end_blk = hex(max(0, int(init_tx["blockNumber"], 16) - 2)), init_tx["blockNumber"]
+    start_blk, end_blk = hex(max(0, int(init_tx["blockNumber"]) - 2)), init_tx["blockNumber"]
     raw_response = base_request("hmy_getBlocks",
                                 params=[start_blk, end_blk, {
                                     "fullTx": True,
@@ -605,7 +605,7 @@ def test_get_blocks_v1():
     for blk in response:
         assert_valid_json_structure(reference_response_blk, blk)
     assert len(response[-1]["transactions"]) > 0, "Expected transaction on last block due to initial transactions"
-    start_num, end_num = int(start_blk, 16), int(end_blk, 16)
+    start_num, end_num = int(start_blk, 16), int(end_blk)
     for blk in response:
         blk_num = int(blk["number"], 16)
         assert start_num <= blk_num <= end_num, f"Got block number {blk_num}, which is not in range [{start_num},{end_num}]"
@@ -665,7 +665,7 @@ def test_get_blocks_v2():
 
     init_tx_record = initial_funding[0]
     init_tx = transaction.get_transaction_by_hash(init_tx_record["hash"], endpoints[init_tx_record["from-shard"]])
-    start_blk, end_blk = max(0, int(init_tx["blockNumber"], 16) - 2), int(init_tx["blockNumber"], 16)
+    start_blk, end_blk = max(0, int(init_tx["blockNumber"]) - 2), int(init_tx["blockNumber"])
     raw_response = base_request("hmyv2_getBlocks",
                                 params=[start_blk, end_blk, {
                                     "fullTx": True,

--- a/localnet/rpc_tests/test_staking.py
+++ b/localnet/rpc_tests/test_staking.py
@@ -739,8 +739,8 @@ def test_get_elected_validator_addresses(s0_validator, s1_validator):
     curr_epoch = blockchain.get_latest_header(endpoint=endpoints[beacon_shard_id])["epoch"]
     val_0_info = staking.get_validator_information(s0_validator["validator-addr"], endpoint=endpoints[beacon_shard_id])
     val_1_info = staking.get_validator_information(s1_validator["validator-addr"], endpoint=endpoints[beacon_shard_id])
-    s0_creation_epoch = int(blockchain.get_block_by_number(val_0_info["validator"]["creation-height"])["epoch"], 16)
-    s1_creation_epoch = int(blockchain.get_block_by_number(val_1_info["validator"]["creation-height"])["epoch"], 16)
+    s0_creation_epoch = int(blockchain.get_block_by_number(val_0_info["validator"]["creation-height"])["epoch"])
+    s1_creation_epoch = int(blockchain.get_block_by_number(val_1_info["validator"]["creation-height"])["epoch"])
 
     while curr_epoch <= s0_creation_epoch or curr_epoch <= s1_creation_epoch or curr_epoch < staking_epoch:
         time.sleep(random.uniform(0.5, 1.5))  # Random to stop burst spam of RPC calls.
@@ -1119,7 +1119,7 @@ def test_get_super_committees(s0_validator):
     staking_epoch = blockchain.get_staking_epoch(endpoints[beacon_shard_id])
     curr_epoch = blockchain.get_latest_header(endpoint=endpoints[beacon_shard_id])["epoch"]
     val_0_info = staking.get_validator_information(s0_validator["validator-addr"], endpoint=endpoints[beacon_shard_id])
-    s0_creation_epoch = int(blockchain.get_block_by_number(val_0_info["validator"]["creation-height"])["epoch"], 16)
+    s0_creation_epoch = int(blockchain.get_block_by_number(val_0_info["validator"]["creation-height"])["epoch"])
 
     while curr_epoch <= s0_creation_epoch or curr_epoch < staking_epoch:
         time.sleep(random.uniform(0.5, 1.5))  # Random to stop burst spam of RPC calls.
@@ -1193,7 +1193,7 @@ def test_get_validator_keys(s0_validator):
     staking_epoch = blockchain.get_staking_epoch(endpoints[beacon_shard_id])
     curr_epoch = blockchain.get_latest_header(endpoint=endpoints[0])["epoch"]
     val_0_info = staking.get_validator_information(s0_validator["validator-addr"], endpoint=endpoints[0])
-    s0_creation_epoch = int(blockchain.get_block_by_number(val_0_info["validator"]["creation-height"])["epoch"], 16)
+    s0_creation_epoch = int(blockchain.get_block_by_number(val_0_info["validator"]["creation-height"])["epoch"])
 
     while curr_epoch <= s0_creation_epoch or curr_epoch < staking_epoch:
         time.sleep(random.uniform(0.5, 1.5))  # Random to stop burst spam of RPC calls.

--- a/localnet/rpc_tests/test_transaction.py
+++ b/localnet/rpc_tests/test_transaction.py
@@ -676,7 +676,7 @@ def test_get_transaction_by_block_hash_and_index_v1():
 
     init_tx_record = initial_funding[0]
     tx = get_transaction(init_tx_record["hash"], init_tx_record["from-shard"])
-    blk = blockchain.get_block_by_hash(tx["blockHash"], endpoint=endpoints[tx["shardID"]], include_full_tx=False)
+    blk = blockchain.get_block_by_hash(tx["blockHash"], endpoint=endpoints[tx["shardID"]], full_tx=False)
     index, blk_hash = blk["transactions"].index(init_tx_record["hash"]), tx["blockHash"]
 
     raw_response = base_request("hmy_getTransactionByBlockHashAndIndex",
@@ -712,7 +712,7 @@ def test_get_transaction_by_block_hash_and_index_v2():
 
     init_tx_record = initial_funding[0]
     tx = get_transaction(init_tx_record["hash"], init_tx_record["from-shard"])
-    blk = blockchain.get_block_by_hash(tx["blockHash"], endpoint=endpoints[tx["shardID"]], include_full_tx=False)
+    blk = blockchain.get_block_by_hash(tx["blockHash"], endpoint=endpoints[tx["shardID"]], full_tx=False)
     index, blk_hash = blk["transactions"].index(init_tx_record["hash"]), tx["blockHash"]
 
     raw_response = base_request("hmyv2_getTransactionByBlockHashAndIndex",
@@ -748,7 +748,7 @@ def test_get_transaction_by_block_number_and_index_v1():
 
     init_tx_record = initial_funding[0]
     tx = get_transaction(init_tx_record["hash"], init_tx_record["from-shard"])
-    blk = blockchain.get_block_by_hash(tx["blockHash"], endpoint=endpoints[tx["shardID"]], include_full_tx=False)
+    blk = blockchain.get_block_by_hash(tx["blockHash"], endpoint=endpoints[tx["shardID"]], full_tx=False)
     index, blk_num = blk["transactions"].index(init_tx_record["hash"]), tx["blockNumber"]
 
     raw_response = base_request("hmy_getTransactionByBlockNumberAndIndex",
@@ -784,7 +784,7 @@ def test_get_transaction_by_block_number_and_index_v2():
 
     init_tx_record = initial_funding[0]
     tx = get_transaction(init_tx_record["hash"], init_tx_record["from-shard"])
-    blk = blockchain.get_block_by_hash(tx["blockHash"], endpoint=endpoints[tx["shardID"]], include_full_tx=False)
+    blk = blockchain.get_block_by_hash(tx["blockHash"], endpoint=endpoints[tx["shardID"]], full_tx=False)
     index, blk_num = blk["transactions"].index(init_tx_record["hash"]), tx["blockNumber"]
 
     raw_response = base_request("hmyv2_getTransactionByBlockNumberAndIndex",

--- a/localnet/rpc_tests/txs.py
+++ b/localnet/rpc_tests/txs.py
@@ -400,5 +400,5 @@ def assert_valid_test_from_address(address, shard, is_staking=False):
     assert account.is_valid_address(address), f"{address} is an invalid ONE address"
     if not account.get_balance(address, endpoint=endpoints[shard]) >= 1e18:
         raise AssertionError(f"Account {address} does not have at least 1 ONE on shard {shard}")
-    if not is_staking and account.get_transaction_count(address, endpoint=endpoints[shard]) != 0:
+    if not is_staking and account.get_transaction_count(address, block_num='latest', endpoint=endpoints[shard]) != 0:
         raise AssertionError(f"Account {address} has already sent a transaction, breaking the txs invariant")


### PR DESCRIPTION
Local test run result:
```
collecting ... collected 91 items

rpc_tests/test_transaction.py::test_send_raw_transaction_v1 PASSED
rpc_tests/test_transaction.py::test_send_raw_transaction_v2 PASSED
rpc_tests/test_transaction.py::test_get_transaction_by_hash_v1 PASSED
rpc_tests/test_transaction.py::test_get_transaction_by_hash_v2 PASSED
rpc_tests/test_transaction.py::test_get_transaction_receipt_v1 PASSED
rpc_tests/test_transaction.py::test_get_transaction_receipt_v2 PASSED
rpc_tests/test_transaction.py::test_get_transaction_by_block_hash_and_index_v1 PASSED
rpc_tests/test_transaction.py::test_get_transaction_by_block_hash_and_index_v2 PASSED
rpc_tests/test_transaction.py::test_get_transaction_by_block_number_and_index_v1 PASSED
rpc_tests/test_transaction.py::test_get_transaction_by_block_number_and_index_v2 PASSED
rpc_tests/test_account.py::test_get_transactions_count PASSED
rpc_tests/test_account.py::test_get_transactions_history_v1 PASSED
rpc_tests/test_account.py::test_get_transactions_history_v2 PASSED
rpc_tests/test_account.py::test_get_balances_by_block_number_v1 PASSED
rpc_tests/test_account.py::test_get_balances_by_block_number_v2 PASSED
rpc_tests/test_blockchain.py::test_invalid_method PASSED
rpc_tests/test_blockchain.py::test_net_peer_count_v1 PASSED
rpc_tests/test_blockchain.py::test_net_peer_count_v2 PASSED
rpc_tests/test_blockchain.py::test_get_node_metadata PASSED
rpc_tests/test_blockchain.py::test_get_sharding_structure PASSED
rpc_tests/test_blockchain.py::test_get_latest_header PASSED
rpc_tests/test_blockchain.py::test_get_latest_chain_headers PASSED
rpc_tests/test_blockchain.py::test_get_leader_address PASSED
rpc_tests/test_blockchain.py::test_get_block_signer_keys PASSED
rpc_tests/test_blockchain.py::test_get_header_by_number PASSED
rpc_tests/test_blockchain.py::test_get_block_signers PASSED
rpc_tests/test_blockchain.py::test_get_block_number_v1 PASSED
rpc_tests/test_blockchain.py::test_get_block_number_v2 PASSED
rpc_tests/test_blockchain.py::test_get_last_sign_power_shard0_v1 PASSED
rpc_tests/test_blockchain.py::test_get_last_sign_power_shard0_v2 PASSED
rpc_tests/test_blockchain.py::test_get_last_sign_power_shard1_v1 PASSED
rpc_tests/test_blockchain.py::test_get_last_sign_power_shard1_v2 PASSED
rpc_tests/test_blockchain.py::test_get_epoch_v1 PASSED
rpc_tests/test_blockchain.py::test_get_epoch_v2 PASSED
rpc_tests/test_blockchain.py::test_get_gas_price_v1 PASSED
rpc_tests/test_blockchain.py::test_get_gas_price_v2 PASSED
rpc_tests/test_blockchain.py::test_get_protocol_version_v1 PASSED
rpc_tests/test_blockchain.py::test_get_protocol_version_v2 PASSED
rpc_tests/test_blockchain.py::test_get_block_transaction_count_by_number_v1 PASSED
rpc_tests/test_blockchain.py::test_get_block_transaction_count_by_number_v2 PASSED
rpc_tests/test_blockchain.py::test_get_block_transaction_count_by_hash_v1 PASSED
rpc_tests/test_blockchain.py::test_get_block_transaction_count_by_hash_v2 PASSED
rpc_tests/test_blockchain.py::test_get_block_by_number_v1 PASSED
rpc_tests/test_blockchain.py::test_get_block_by_number_v2 PASSED
rpc_tests/test_blockchain.py::test_get_blocks_v1 PASSED
rpc_tests/test_blockchain.py::test_get_blocks_v2 boot completed for shard 0 ( 4 streams are connected )
boot completed for shard 0 ( 5 streams are connected )
PASSED
rpc_tests/test_blockchain.py::test_get_block_by_hash_v1 PASSED
rpc_tests/test_blockchain.py::test_get_block_by_hash_v2 PASSED
rpc_tests/test_contract.py::test_call_v1 PASSED
rpc_tests/test_contract.py::test_call_v2 PASSED
rpc_tests/test_contract.py::test_estimate_gas_v1 PASSED
rpc_tests/test_contract.py::test_estimate_gas_v2 PASSED
rpc_tests/test_contract.py::test_get_code_v1 PASSED
rpc_tests/test_contract.py::test_get_code_v2 PASSED
rpc_tests/test_contract.py::test_get_storage_at_v1 PASSED
rpc_tests/test_contract.py::test_get_storage_at_v2 PASSED
rpc_tests/test_staking.py::test_delegation PASSED
rpc_tests/test_staking.py::test_undelegation PASSED
rpc_tests/test_staking.py::test_get_all_validator_addresses PASSED
rpc_tests/test_staking.py::test_get_transaction_receipt_v1 PASSED
rpc_tests/test_staking.py::test_get_transaction_receipt_v2 PASSED
rpc_tests/test_staking.py::test_get_staking_transactions_count PASSED
rpc_tests/test_staking.py::test_get_all_validator_information PASSED
rpc_tests/test_staking.py::test_get_validator_information PASSED
rpc_tests/test_staking.py::test_get_validator_information_by_block_number PASSED
rpc_tests/test_staking.py::test_get_all_validator_information_by_block_number PASSED
rpc_tests/test_staking.py::test_get_elected_validator_addresses PASSED
rpc_tests/test_staking.py::test_get_delegations_by_delegator PASSED
rpc_tests/test_staking.py::test_get_delegations_by_delegator_by_block_number PASSED
rpc_tests/test_staking.py::test_get_delegations_by_validator PASSED
rpc_tests/test_staking.py::test_get_current_utility_metrics PASSED
rpc_tests/test_staking.py::test_get_median_raw_stake_snapshot SKIPPED
rpc_tests/test_staking.py::test_get_super_committees PASSED
rpc_tests/test_staking.py::test_get_staking_network_info PASSED
rpc_tests/test_staking.py::test_get_validator_keys PASSED
rpc_tests/test_staking.py::test_get_validators_v1 SKIPPED (This test...)
rpc_tests/test_staking.py::test_get_validators_v2 SKIPPED (This test...)
rpc_tests/test_staking.py::test_pending_staking_transactions_v1 PASSED
rpc_tests/test_staking.py::test_pending_staking_transactions_v2 PASSED
rpc_tests/test_staking.py::test_get_blocks_v1 PASSED
rpc_tests/test_staking.py::test_get_blocks_v2 PASSED
rpc_tests/test_staking.py::test_get_staking_transaction_history_v1 PASSED
rpc_tests/test_staking.py::test_get_staking_transaction_history_v2 PASSED
rpc_tests/test_transaction.py::test_get_pool_stats PASSED
rpc_tests/test_transaction.py::test_get_current_transaction_error_sink PASSED
rpc_tests/test_transaction.py::test_resend_cx PASSED
rpc_tests/test_transaction.py::test_get_pending_cx_receipts PASSED
rpc_tests/test_transaction.py::test_get_cx_receipt_by_hash_v1 PASSED
rpc_tests/test_transaction.py::test_get_cx_receipt_by_hash_v2 PASSED
rpc_tests/test_transaction.py::test_pending_transactions_v1 PASSED
rpc_tests/test_transaction.py::test_pending_transactions_v2 PASSED
===Flaky Test Report===

test_get_block_signer_keys passed 1 out of the required 1 times. Success!
test_get_block_signers passed 1 out of the required 1 times. Success!
test_undelegation passed 1 out of the required 1 times. Success!
test_get_elected_validator_addresses passed 1 out of the required 1 times. Success!
test_get_super_committees passed 1 out of the required 1 times. Success!
test_get_validator_keys passed 1 out of the required 1 times. Success!
test_resend_cx passed 1 out of the required 1 times. Success!
test_get_pending_cx_receipts passed 1 out of the required 1 times. Success!
test_get_cx_receipt_by_hash_v1 passed 1 out of the required 1 times. Success!
test_get_cx_receipt_by_hash_v2 passed 1 out of the required 1 times. Success!

===End Flaky Test Report===

=========================== short test summary info ============================
SKIPPED [1] rpc_tests/test_staking.py:940: This test is flaky and needs to be fixed
SKIPPED [1] rpc_tests/test_staking.py:1217: This test is flaky and needs to be fixed
SKIPPED [1] rpc_tests/test_staking.py:1256: This test is flaky and needs to be fixed
=================== 88 passed, 3 skipped in 72.20s (0:01:12) ===================

=== FINISHED RPC TESTS ===
```