### PR TITLE
fix(rosetta) - fix output redirection to have a way for manual local debug

### DIFF
--- a/localnet/scripts/run.sh
+++ b/localnet/scripts/run.sh
@@ -99,13 +99,17 @@ function rosetta_tests() {
   pwd
   echo "dir: $DIR/../configs/localnet_rosetta_test_s0.json"
   echo "[ROSETTA] check:construction s0"
-  rosetta-cli check:construction --configuration-file "$DIR/../configs/localnet_rosetta_test_s0.json" > /dev/null 2>1 || error=1
+  rosetta-cli check:construction --configuration-file \
+    "$DIR/../configs/localnet_rosetta_test_s0.json" > output_rossetta.log 2>&1 || error=1
   echo "[ROSETTA] check:data s0"
-  rosetta-cli check:data --configuration-file "$DIR/../configs/localnet_rosetta_test_s0.json" > /dev/null 2>1 || error=1
+  rosetta-cli check:data --configuration-file \
+    "$DIR/../configs/localnet_rosetta_test_s0.json" >> output_rossetta.log 2>&1 || error=1
   echo "[ROSETTA] check:construction s1"
-  rosetta-cli check:construction --configuration-file "$DIR/../configs/localnet_rosetta_test_s1.json" > /dev/null 2>1 || error=1
+  rosetta-cli check:construction --configuration-file \
+    "$DIR/../configs/localnet_rosetta_test_s1.json" >> output_rossetta.log 2>&1 || error=1
   echo "[ROSETTA] check:data s1"
-  rosetta-cli check:data --configuration-file "$DIR/../configs/localnet_rosetta_test_s1.json" > /dev/null 2>1 || error=1
+  rosetta-cli check:data --configuration-file \
+    "$DIR/../configs/localnet_rosetta_test_s1.json" >> output_rossetta.log 2>&1 || error=1
   echo -e "\n=== \e[38;5;0;48;5;255mFINISHED ROSETTA API TESTS\e[0m ===\n"
   if ((error == 1)); then
     echo "FAILED ROSETTA TESTS"


### PR DESCRIPTION
What was done:
* instead of redirecting stdout to /dev/null and stderr to the file `1`, we can just redirect both of them to the one file named `output_rossetta.log`  for each rosetta run, final file is just 315 kb
* note: I've tried to silence the logs like `2025-02-12 14:42:03 Rosetta: POST /account/balance 194.038µs`, but they are just ignoring the standard stdout and stderr, and printing directly to the current tty and for me this is a huge overhead to implement, but maybe it even worth to create an issue in the rossetta-cli repo - https://github.com/coinbase/mesh-cli 