### PR TITLE
fix(Dockerfile): change rossetta cli github link

### DIFF
--- a/localnet/Dockerfile
+++ b/localnet/Dockerfile
@@ -43,8 +43,8 @@ RUN curl -L -o /go/bin/hmy https://harmony.one/hmycli > /dev/null 2>1 && chmod +
 
 WORKDIR $GOPATH/src/github.com/coinbase
 
-RUN git clone https://github.com/coinbase/rosetta-cli.git > /dev/null 2>1
-RUN cd rosetta-cli && make install > /dev/null 2>1
+RUN git clone https://github.com/coinbase/mesh-cli.git > /dev/null 2>1
+RUN cd mesh-cli && make install > /dev/null 2>1
 
 WORKDIR $GOPATH/src/github.com/harmony-one/harmony-test/localnet
 


### PR DESCRIPTION
In short what was that:
* repo `git clone https://github.com/coinbase/rosetta-cli.git` has changed its name a while ago
* redirection from old to new was working fine until today
* simple change for the repo name helped 

Tests done:
* https://app.travis-ci.com/github/harmony-one/harmony/jobs/631875038#L538-L542
* https://app.travis-ci.com/github/harmony-one/harmony/jobs/631875039#L545-L549