### PR TITLE
feature - enable hmy test suite

### DIFF
--- a/localnet/Dockerfile
+++ b/localnet/Dockerfile
@@ -9,57 +9,71 @@ ARG MAIN_REPO_ORG
 ENV BRANCH=${MAIN_REPO_BRANCH}
 ENV MAIN_REPO=${MAIN_REPO_ORG}
 
-WORKDIR $GOPATH/src/github.com/harmony-one
+WORKDIR "$GOPATH/src/github.com/harmony-one"
 
 SHELL ["/bin/bash", "-c"]
 
-# These are split into multiple lines to allow debugging the error message that I cannot reproduce locally
-# The command `xxx` returned a non-zero code: 100
-RUN apt clean > /dev/null 2>1
-RUN apt update > /dev/null 2>1
-RUN apt upgrade -y > /dev/null 2>1
-RUN apt update -y > /dev/null 2>1
-RUN apt install -y unzip libgmp-dev libssl-dev curl git jq make gcc g++ bash sudo python3 python3-pip > /dev/null 2>1
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN git clone --branch ${BRANCH} https://github.com/${MAIN_REPO}/harmony.git > /dev/null 2>1 \
-    && git clone https://github.com/harmony-one/bls.git > /dev/null 2>1 \
-    && git clone https://github.com/harmony-one/mcl.git > /dev/null 2>1 \
-    && git clone --branch fix_wait_for_elected_validators https://github.com/mur-me/pyhmy.git > /dev/null 2>1
+RUN apt-get clean > /dev/null 2>&1 && \
+    apt-get update > /dev/null 2>&1 && \
+    apt-get upgrade -y > /dev/null 2>&1 && \
+    apt-get install -y --no-install-recommends \
+        bash=5.2.15-2+b7 \
+        curl=7.88.1-10+deb12u12 \
+        g++=4:12.2.0-3 \
+        gcc=4:12.2.0-3 \
+        git=1:2.39.5-0+deb12u2 \
+        jq=1.6-2.1 \
+        libgmp-dev=2:6.2.1+dfsg1-1.1 \
+        libssl-dev=3.0.15-1~deb12u1 \
+        make=4.3-4.1 \
+        python3=3.11.2-1+b1 \
+        python3-pip=23.0.1+dfsg-1 \
+        sudo=1.9.13p3-1+deb12u1 \
+        unzip=6.0-28 > /dev/null 2>&1 && \
+    apt-get clean > /dev/null 2>&1 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Fix complaints about Docker / root / user ownership for Golang "VCS stamping"
 # https://github.com/golang/go/blob/3900ba4baf0e3b309a55b5ac4dd25f709df09772/src/cmd/go/internal/vcs/vcs.go
-RUN git config --global --add safe.directory $GOPATH/src/github.com/harmony-one/harmony > /dev/null 2>1 \
-    && git config --global --add safe.directory $GOPATH/src/github.com/harmony-one/bls > /dev/null 2>1 \
-    && git config --global --add safe.directory $GOPATH/src/github.com/harmony-one/mcl > /dev/null 2>1 \
-    && git config --global --add safe.directory $GOPATH/src/github.com/harmony-one/pyhmy > /dev/null 2>1
+RUN git clone --branch ${BRANCH} https://github.com/${MAIN_REPO}/harmony.git > /dev/null 2>&1 && \
+    git clone https://github.com/harmony-one/bls.git > /dev/null 2>&1 && \
+    git clone https://github.com/harmony-one/mcl.git > /dev/null 2>&1 && \
+    git clone https://github.com/harmony-one/pyhmy.git > /dev/null 2>&1 && \
+    git config --global --add safe.directory "$GOPATH/src/github.com/harmony-one/harmony" > /dev/null 2>&1 && \
+    git config --global --add safe.directory "$GOPATH/src/github.com/harmony-one/bls" > /dev/null 2>&1 && \
+    git config --global --add safe.directory "$GOPATH/src/github.com/harmony-one/mcl" > /dev/null 2>&1 && \
+    git config --global --add safe.directory "$GOPATH/src/github.com/harmony-one/pyhmy" > /dev/null 2>&1
 
+WORKDIR "$GOPATH/src/github.com/harmony-one/harmony"
 # Build to fetch all dependencies for faster test builds
-RUN cd harmony > /dev/null 2>&1 \
-    && go mod tidy > /dev/null 2>&1 \
-    && bash scripts/install_build_tools.sh > /dev/null 2>&1 \
-    && make > /dev/null 2>&1
-RUN rm -rf harmony
+RUN go mod tidy > /dev/null 2>&1 && \
+    bash scripts/install_build_tools.sh > /dev/null 2>&1 && \
+    make > /dev/null 2>&1
+WORKDIR "$GOPATH/src/github.com/coinbase/mesh-cli"
+RUN rm -rf "$GOPATH/src/github.com/harmony-one/harmony"
 
 # Install testing tools
-RUN curl -L -o /go/bin/hmy https://harmony.one/hmycli > /dev/null 2>1 && chmod +x /go/bin/hmy > /dev/null 2>1
+RUN curl -L -o /go/bin/hmy https://harmony.one/hmycli > /dev/null 2>&1 && \
+    chmod +x /go/bin/hmy > /dev/null 2>&1
 
-WORKDIR $GOPATH/src/github.com/coinbase
+RUN git clone https://github.com/coinbase/mesh-cli.git . > /dev/null 2>&1 && \
+    make install > /dev/null 2>&1
 
-RUN git clone https://github.com/coinbase/mesh-cli.git > /dev/null 2>1
-RUN cd mesh-cli && make install > /dev/null 2>1
+WORKDIR "$GOPATH/src/github.com/harmony-one/harmony-test/localnet"
 
-WORKDIR $GOPATH/src/github.com/harmony-one/harmony-test/localnet
-
-COPY scripts scripts
-COPY rpc_tests rpc_tests
-COPY configs configs
+COPY scripts/ scripts/
+COPY rpc_tests/ rpc_tests/
+COPY configs/ configs/
 COPY requirements.txt requirements.txt
 
 # Since we are running as root in Docker, `--break-system-packages` is required
-RUN python3 -m pip install -r requirements.txt --break-system-packages --no-cache-dir > /dev/null 2>&1 && rm requirements.txt
+RUN python3 -m pip install -r requirements.txt --break-system-packages --no-cache-dir > /dev/null 2>&1 && \
+    rm requirements.txt && \
+    chmod +x "scripts/run.sh"
 WORKDIR $GOPATH/src/github.com/harmony-one/pyhmy
-RUN python3 -m pip install . --break-system-packages --no-cache-dir && \
-    chmod +x "$GOPATH"/src/github.com/harmony-one/harmony-test/localnet/scripts/run.sh
+RUN python3 -m pip install . --break-system-packages --no-cache-dir > /dev/null 2>&1
 
 WORKDIR $GOPATH/src/github.com/harmony-one/harmony
 ENTRYPOINT ["/go/src/github.com/harmony-one/harmony-test/localnet/scripts/run.sh"]

--- a/localnet/Dockerfile
+++ b/localnet/Dockerfile
@@ -23,13 +23,15 @@ RUN apt install -y unzip libgmp-dev libssl-dev curl git jq make gcc g++ bash sud
 
 RUN git clone --branch ${BRANCH} https://github.com/${MAIN_REPO}/harmony.git > /dev/null 2>1 \
     && git clone https://github.com/harmony-one/bls.git > /dev/null 2>1 \
-    && git clone https://github.com/harmony-one/mcl.git > /dev/null 2>1
+    && git clone https://github.com/harmony-one/mcl.git > /dev/null 2>1 \
+    && git clone --branch fix_wait_for_elected_validators https://github.com/mur-me/pyhmy.git > /dev/null 2>1
 
 # Fix complaints about Docker / root / user ownership for Golang "VCS stamping"
 # https://github.com/golang/go/blob/3900ba4baf0e3b309a55b5ac4dd25f709df09772/src/cmd/go/internal/vcs/vcs.go
 RUN git config --global --add safe.directory $GOPATH/src/github.com/harmony-one/harmony > /dev/null 2>1 \
     && git config --global --add safe.directory $GOPATH/src/github.com/harmony-one/bls > /dev/null 2>1 \
-    && git config --global --add safe.directory $GOPATH/src/github.com/harmony-one/mcl > /dev/null 2>1
+    && git config --global --add safe.directory $GOPATH/src/github.com/harmony-one/mcl > /dev/null 2>1 \
+    && git config --global --add safe.directory $GOPATH/src/github.com/harmony-one/pyhmy > /dev/null 2>1
 
 # Build to fetch all dependencies for faster test builds
 RUN cd harmony > /dev/null 2>&1 \
@@ -54,8 +56,10 @@ COPY configs configs
 COPY requirements.txt requirements.txt
 
 # Since we are running as root in Docker, `--break-system-packages` is required
-RUN python3 -m pip install -r requirements.txt --break-system-packages > /dev/null 2>1 && rm requirements.txt
-RUN chmod +x $GOPATH/src/github.com/harmony-one/harmony-test/localnet/scripts/run.sh
+RUN python3 -m pip install -r requirements.txt --break-system-packages --no-cache-dir > /dev/null 2>&1 && rm requirements.txt
+WORKDIR $GOPATH/src/github.com/harmony-one/pyhmy
+RUN python3 -m pip install . --break-system-packages --no-cache-dir && \
+    chmod +x "$GOPATH"/src/github.com/harmony-one/harmony-test/localnet/scripts/run.sh
 
 WORKDIR $GOPATH/src/github.com/harmony-one/harmony
 ENTRYPOINT ["/go/src/github.com/harmony-one/harmony-test/localnet/scripts/run.sh"]

--- a/localnet/rpc_tests/test_debug.py
+++ b/localnet/rpc_tests/test_debug.py
@@ -962,7 +962,6 @@ def test_debug_traceCall_override_sending_one_to_other_address():
         endpoint=debug_endpoints[0],
     )
     response = check_and_unpack_rpc_response(raw_response, expect_error=False)
-    print(response)
     assert_valid_json_structure(reference_response, response)
     assert response["value"] == one_to_send
     assert response["gas"] == "0x0"

--- a/localnet/scripts/run.sh
+++ b/localnet/scripts/run.sh
@@ -3,6 +3,7 @@ set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 harmony_dir="$(go env GOPATH)/src/github.com/harmony-one/harmony"
+pyhmy_dir="$(go env GOPATH)/src/github.com/harmony-one/pyhmy"
 localnet_config=$(realpath "$DIR/../configs/localnet_deploy.config")
 
 function stop() {
@@ -85,6 +86,25 @@ function rpc_tests() {
     echo "Passed RPC tests"
   fi
 }
+
+function pyhmy_tests() {
+  echo -e "\n=== \e[38;5;0;48;5;255mSTARTING PYHMY TESTS\e[0m ===\n"
+  build_and_start_localnet || exit 1 &
+  sleep 30
+  # WARNING: Assumtion is that EPOCH 2 can process ALL test transaction types...
+  wait_for_epoch 2 300 # Timeout at ~900 seconds
+
+  echo "Starting pyhmy test suite"
+  sleep 3
+  cd "${pyhmy_dir}" && make test || error=1
+  echo -e "\n=== \e[38;5;0;48;5;255mFINISHED PYHMY TESTS\e[0m ===\n"
+  if ((error == 1)); then
+    echo "FAILED PYHMY TESTS"
+  else
+    echo "Passed PYHMY tests"
+  fi
+}
+
 
 function rosetta_tests() {
   echo -e "\n=== \e[38;5;0;48;5;255mSTARTING ROSETTA API TESTS\e[0m ===\n"
@@ -182,21 +202,30 @@ KEEP=false
 GO=true
 RPC=true
 ROSETTA=true
+PYHMY=true
 
-while getopts "Bkgnr" option; do
+while getopts "Bkgnpr" option; do
   case ${option} in
   B) BUILD=false ;;
   k) KEEP=true ;;
-  g) RPC=false
+  g) PYHMY=false
+     RPC=false
      ROSETTA=false
   ;;
   n)
     GO=false
+    PYHMY=false
     ROSETTA=false
   ;;
   r)
     GO=false
+    PYHMY=false
     RPC=false
+  ;;
+  p)
+    GO=false
+    RPC=false
+    ROSETTA=false
   ;;
   *) echo "
 Integration tester for localnet
@@ -206,6 +235,7 @@ Option:      Help:
 -k           Keep localnet running after Node API tests are finished
 -g           ONLY run go tests & checks
 -n           ONLY run the RPC tests
+-p           ONLY run the pyhmy tests
 -r           ONLY run the rosetta API tests
 "
   exit 0
@@ -225,6 +255,10 @@ fi
 
 if [ "$ROSETTA" == "true" ]; then
   rosetta_tests
+fi
+
+if [ "$PYHMY" == "true" ]; then
+  pyhmy_tests
 fi
 
 exit "$error"


### PR DESCRIPTION
NOTE: 
* merge - https://github.com/harmony-one/pyhmy/pull/41 before merging this pr
* `git clone --branch fix_wait_for_elected_validators https://github.com/mur-me/pyhmy.git > /dev/null 2>&1 && \` should be changed to `git clone https://github.com/harmony-one/pyhmy.git > /dev/null 2>&1 && \` 

What was done:
* main change - add hmy tests to the run.sh script - idea is completely the as for the RPC tests - wait for the 2nd epoch and run the test suite
* do a refactor on the Dockerfile:
  * fix the stdout and stderr redirection to the /dev/null
  * change apt to apt-get, because apt is designed for the user input
  * pin apt dependencies versions
  * unify extra RUN commands
  * no more `cd folder` in the RUN commands - now we are using only [WORKDIR](https://github.com/hadolint/hadolint/wiki/DL3003)
  * put slashes on the COPY command, to highlight that we are using folders here explicitly

Example of the green run: https://app.travis-ci.com/github/harmony-one/harmony/builds/275141167
  