### PR TITLE
fix(rpc_tests): add 0x to the returnValue in the debug tests

### DIFF
--- a/localnet/rpc_tests/test_debug.py
+++ b/localnet/rpc_tests/test_debug.py
@@ -363,7 +363,7 @@ def test_debug_traceCall_state_override_different_simulated_call():
     assert response["gas"] == DEFAULT_GAS + calldata_gas_used + simulated_gas_used
     assert (
         response["returnValue"]
-        == "0000000000000000000000000000000000000000000000000000000000000001"
+        == "0x0000000000000000000000000000000000000000000000000000000000000001"
         + "0000000000000000000000000000000000000000000000000000000000000002"
     )
 
@@ -540,7 +540,7 @@ def test_debug_traceCall_block_and_state_override():
     assert response["gas"] == DEFAULT_GAS + calldata_gas_used + simulated_gas_used
     assert (
         response["returnValue"]
-        == "0000000000000000000000000000000000000000000000000000000000000001"
+        == "0x0000000000000000000000000000000000000000000000000000000000000001"
     )
 
 


### PR DESCRIPTION
What was done: 
* fix 2 tests to match the same behavior as in https://github.com/harmony-one/harmony/blob/4fc19b63c144531d6d2b56abe5e2f5a22ba24690/hmy/tracers/logger/logger.go#L100  - `0x-prefixed
* run rpc test suite locally:
```
test_debug_traceCall_state_override_different_simulated_call 
PASSED
test_debug_traceCall_block_and_state_override
PASSED
```